### PR TITLE
Run scripts without "-e"

### DIFF
--- a/src/class-main.php
+++ b/src/class-main.php
@@ -77,29 +77,23 @@ foreach ($argv as $i => $val) {
   $argv[$i]= iconv('utf-7', \xp::ENCODING, $val);
 }
 
-$ext= substr($argv[0], -4, 4);
-if ('.php' === $ext) {
-  if (false === ($uri= realpath($argv[0]))) {
-    throw new \Exception('Cannot load '.$argv[0].' - does not exist');
-  }
-  if (null === ($cl= \lang\ClassLoader::getDefault()->findUri($uri))) {
-    if (strstr($uri, '.class.php')) {
+if (is_file($argv[0])) {
+  if (0 === substr_compare($argv[0], '.class.php', -10)) {
+    $uri= realpath($argv[0]);
+    if (null === ($cl= \lang\ClassLoader::getDefault()->findUri($uri))) {
       throw new \Exception('Cannot load '.$uri.' - not in class path');
     }
+    $class= $cl->loadUri($uri);
+  } else if (0 === substr_compare($argv[0], '.xar', -4)) {
+    $cl= \lang\ClassLoader::registerPath(realpath($argv[0]));
+    if (!$cl->providesResource('META-INF/manifest.ini')) {
+      throw new \Exception($cl->toString().' does not provide a manifest');
+    }
+    $class= $cl->loadClass(parse_ini_string($cl->getResource('META-INF/manifest.ini'))['main-class']);
+  } else {
     $class= \lang\XPClass::forName('xp.runtime.Evaluate');
     array_unshift($argv, 'eval');
-  } else {
-    $class= $cl->loadUri($uri);
   }
-} else if ('.xar' === $ext) {
-  if (false === ($uri= realpath($argv[0]))) {
-    throw new \Exception('Cannot load '.$argv[0].' - does not exist');
-  }
-  $cl= \lang\ClassLoader::registerPath($uri);
-  if (!$cl->providesResource('META-INF/manifest.ini')) {
-    throw new \Exception($cl->toString().' does not provide a manifest');
-  }
-  $class= $cl->loadClass(parse_ini_string($cl->getResource('META-INF/manifest.ini'))['main-class']);
 } else {
   $class= \lang\ClassLoader::getDefault()->loadClass($argv[0]);
 }

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -79,6 +79,7 @@ require 'class-path.php';
 require 'entry.php';
 
 $class= entry($argv);
+$_SERVER['argv']= $argv;
 try {
   exit($class->getMethod('main')->invoke(null, array(array_slice($argv, 1))));
 } catch (\lang\SystemExit $e) {

--- a/src/entry.php
+++ b/src/entry.php
@@ -1,24 +1,23 @@
 <?php namespace xp;
 
 function entry(&$argv) {
-  $ext= substr($argv[0], -4, 4);
-  if ('.php' === $ext) {
-    if (false === ($uri= realpath($argv[0]))) {
-      throw new \Exception('Cannot load '.$argv[0].' - does not exist');
+  if (is_file($argv[0])) {
+    if (0 === substr_compare($argv[0], '.class.php', -10)) {
+      $uri= realpath($argv[0]);
+      if (null === ($cl= \lang\ClassLoader::getDefault()->findUri($uri))) {
+        throw new \Exception('Cannot load '.$uri.' - not in class path');
+      }
+      return $cl->loadUri($uri);
+    } else if (0 === substr_compare($argv[0], '.xar', -4)) {
+      $cl= \lang\ClassLoader::registerPath(realpath($argv[0]));
+      if (!$cl->providesResource('META-INF/manifest.ini')) {
+        throw new \Exception($cl->toString().' does not provide a manifest');
+      }
+      return $cl->loadClass(parse_ini_string($cl->getResource('META-INF/manifest.ini'))['main-class']);
+    } else {
+      return \lang\ClassLoader::getDefault()->loadClass('xp.runtime.Evaluate');
+      array_unshift($argv, 'eval');
     }
-    if (null === ($cl= \lang\ClassLoader::getDefault()->findUri($uri))) {
-      throw new \Exception('Cannot load '.$argv[0].' - not in class path');
-    }
-    return $cl->loadUri($uri);
-  } else if ('.xar' === $ext) {
-    if (false === ($uri= realpath($argv[0]))) {
-      throw new \Exception('Cannot load '.$argv[0].' - does not exist');
-    }
-    $cl= \lang\ClassLoader::registerPath($uri);
-    if (!$cl->providesResource('META-INF/manifest.ini')) {
-      throw new \Exception($cl->toString().' does not provide a manifest');
-    }
-    return $cl->loadClass(parse_ini_string($cl->getResource('META-INF/manifest.ini'))['main-class']);
   } else {
     return \lang\ClassLoader::getDefault()->loadClass($argv[0]);
   }

--- a/test/shared/entry-test.php
+++ b/test/shared/entry-test.php
@@ -13,6 +13,7 @@ exit($test->run([
     file_put_contents($path->compose($this->classpath, 'test.xar'), 'CCA...');
     file_put_contents($path->compose($this->classpath, 'notrunnable.xar'), 'CCA...');
     file_put_contents($path->compose($this->classpath, 'Test.script.php'), '<?php ');
+    file_put_contents($path->compose($this->classpath, 'test'), '#!/usr/bin/env xp');
 
     class_exists('lang\\ClassLoader') || eval('namespace lang; class ClassLoader {
       private $path;
@@ -72,6 +73,11 @@ exit($test->run([
 
   'script file entry point' => function() use($path) {
     $argv= [$path->compose($this->classpath, 'Test.script.php')];
+    $this->assertEquals('xp.runtime.Evaluate', \xp\entry($argv));
+  },
+
+  'script file entry point does not require .php extension' => function() use($path) {
+    $argv= [$path->compose($this->classpath, 'test')];
     $this->assertEquals('xp.runtime.Evaluate', \xp\entry($argv));
   },
 ]));

--- a/test/shared/entry-test.php
+++ b/test/shared/entry-test.php
@@ -12,6 +12,7 @@ exit($test->run([
     file_put_contents($path->compose($this->classpath, 'NotInClassPath.class.php'), '<?php class NotInClassPath { }');
     file_put_contents($path->compose($this->classpath, 'test.xar'), 'CCA...');
     file_put_contents($path->compose($this->classpath, 'notrunnable.xar'), 'CCA...');
+    file_put_contents($path->compose($this->classpath, 'Test.script.php'), '<?php ');
 
     class_exists('lang\\ClassLoader') || eval('namespace lang; class ClassLoader {
       private $path;
@@ -67,5 +68,10 @@ exit($test->run([
       '/.+ does not provide a manifest/',
       function() use($argv) { \xp\entry($argv); }
     );
+  },
+
+  'script file entry point' => function() use($path) {
+    $argv= [$path->compose($this->classpath, 'Test.script.php')];
+    $this->assertEquals('xp.runtime.Evaluate', \xp\entry($argv));
   },
 ]));


### PR DESCRIPTION
Given the following `AgeInDays.script.php`

``` php
<?php
use util\{Date, DateUtil};
use util\cmd\Console;

$span= DateUtil::timespanBetween(new Date($argv[1]), Date::now());
Console::writeLine('Hey, you are ', $span->getDays(), ' days old');
```

Previously only `xp -e AgeInDays.script.php` worked, this pull request detects a non-class.php file and runs it via `xp.runtime.Evaluate`:

``` sh
$ xp AgeInDays.script.php 1977-12-14
Hey, you are 13934 days old
```
