### PR TITLE
Invoke main() method directly instead of using reflection

### DIFF
--- a/src/class-main.php
+++ b/src/class-main.php
@@ -82,7 +82,7 @@ $class= require 'entry.php', entry($argv);
 $_SERVER['argv']= $argv;
 
 try {
-  exit($class->getMethod('main')->invoke(null, array(array_slice($argv, 1))));
+  exit($class::main(array_slice($argv, 1)));
 } catch (\lang\SystemExit $e) {
   if ($message= $e->getMessage()) echo $message, "\n";
   exit($e->getCode());

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -4,8 +4,17 @@ set_exception_handler(function($e) {
   if ($e instanceof \lang\Throwable) {
     fputs(STDERR, 'Uncaught exception: '.$e->toString());
   } else {
-    fputs(STDERR, 'Uncaught exception: '.get_class($e).' ('.$e->getMessage().")\n");
     $stringOf= class_exists('xp', false) ? array('xp', 'stringOf') : function($val) { return var_export($val, 1); };
+    fprintf(
+      STDERR,
+      "Uncaught exception: %s (%s)\n  at <source> [line %d of %s]\n  at <main>(%s) [line 0 of %s]\n",
+      get_class($e),
+      $e->getMessage(),
+      $e->getLine(),
+      str_replace(getcwd(), '.', $e->getFile()),
+      implode(', ', array_map($stringOf, array_slice($_SERVER['argv'], 1))),
+      str_replace('.', DIRECTORY_SEPARATOR, $_SERVER['argv'][0]).'.class.php'
+    );
     foreach ($e->getTrace() as $trace) {
       fprintf(STDERR,
         "  at %s%s%s(%s) [line %d of %s]\n",

--- a/src/entry.php
+++ b/src/entry.php
@@ -7,18 +7,19 @@ function entry(&$argv) {
       if (null === ($cl= \lang\ClassLoader::getDefault()->findUri($uri))) {
         throw new \Exception('Cannot load '.$uri.' - not in class path');
       }
-      return $cl->loadUri($uri);
+      return $cl->loadUri($uri)->literal();
     } else if (0 === substr_compare($argv[0], '.xar', -4)) {
       $cl= \lang\ClassLoader::registerPath(realpath($argv[0]));
       if (!$cl->providesResource('META-INF/manifest.ini')) {
         throw new \Exception($cl->toString().' does not provide a manifest');
       }
-      return $cl->loadClass(parse_ini_string($cl->getResource('META-INF/manifest.ini'))['main-class']);
+      $manifest= parse_ini_string($cl->getResource('META-INF/manifest.ini'));
+      return strtr($manifest['main-class'], '.', '\\');
     } else {
       array_unshift($argv, 'eval');
-      return \lang\ClassLoader::getDefault()->loadClass('xp.runtime.Evaluate');
+      return 'xp\runtime\Evaluate';
     }
   } else {
-    return \lang\ClassLoader::getDefault()->loadClass($argv[0]);
+    return strtr($argv[0], '.', '\\');
   }
 }

--- a/src/entry.php
+++ b/src/entry.php
@@ -9,7 +9,7 @@ function entry(&$argv) {
       }
       return $cl->loadUri($uri)->literal();
     } else if (0 === substr_compare($argv[0], '.xar', -4)) {
-      $cl= \lang\ClassLoader::registerPath(realpath($argv[0]));
+      $cl= \lang\ClassLoader::registerPath($argv[0]);
       if (!$cl->providesResource('META-INF/manifest.ini')) {
         throw new \Exception($cl->toString().' does not provide a manifest');
       }


### PR DESCRIPTION
This brings us closer to removing reflection from core

_See https://github.com/xp-framework/rfc/issues/298#issuecomment-174314209_

This introduces a subtle change when the class does not have a main() method:

**Before**:

``` sh
$ xp Test arg1 arg2
Uncaught exception: Exception lang.ElementNotFoundException (No such method "main" in class Test)
  at lang.XPClass::getMethod((0x4)'main') [line 349 of class-main.php]
```

**After**:

``` sh
$ XP_RT=7.0 xp Test arg1 arg2
Uncaught exception: Error (Call to undefined method Test::main())
  at <source> [line 364 of .\bin\class-main.php]
  at <main>("arg1", "arg2") [line 0 of Test.class.php]

$ XP_RT=5.6 xp Test arg1 arg2
Uncaught error: Fatal error (Call to undefined method Test::main())
  at <source> [line 364 of .\bin\class-main.php]
  at <main>("arg1", "arg2") [line 0 of Test.class.php]
```
